### PR TITLE
add parent LogicalTreeNode to block attach params

### DIFF
--- a/src/skeleton/Blocks.scala
+++ b/src/skeleton/Blocks.scala
@@ -6,6 +6,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
 
 case class BlockAttachParams(
   fbus: TLBusWrapper,
@@ -13,6 +14,7 @@ case class BlockAttachParams(
   pbus: TLBusWrapper,
   ibus: IntInwardNode,
   testHarness: LazyScope,
+  parentNode: LogicalTreeNode,
   )(implicit val p: Parameters)
 
 case class BlockDescriptor(

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -40,7 +40,8 @@ class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubs
     mbus = mbus,
     pbus = pbus,
     ibus = ibus.fromSync,
-    testHarness = harness)
+    testHarness = harness,
+    parentNode = logicalTreeNode)
 
   p(BlockDescriptorKey).foreach { block => block.place(attachParams) }
 


### PR DESCRIPTION
so that blocks can attach their `LogicalTreeNode` to the parent