### PR TITLE
Backport /../ from wake, until we support wake 0.16 everywhere.

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -1,3 +1,16 @@
+# Borrowed from future wake; can be removed once we've migrated to wake 0.16
+def root /../ filterFn = jfind filterFn root
+def jfind filterFn root =
+  def helper node acc = match node
+    JArray l =
+      def tail = foldr helper acc l
+      if filterFn node then node, tail else tail
+    JObject l =
+      def tail = foldr (helper _.getPairSecond _) acc l
+      if filterFn node then node, tail else tail
+    _ =
+      if filterFn node then node, acc else acc
+  helper root Nil | JArray
 
 global def sifiveSkeletonScalaModule =
   makeScalaModuleFromJSON here "sifiveSkeleton"


### PR DESCRIPTION
#3 introduces a regression to any environment that is on wake 0.15 or lower. To ease the transition, let's include this backported `/../` operator, which I copied from https://github.com/sifive/api-generator-sifive/pull/4.

I promise we'll schedule time to upgrade everything to wake 0.17 this quarter!