### PR TITLE
Add fpga test socket parent node

### DIFF
--- a/design/craft/fpga-test-socket/src/TestSocketFPGADesign.scala
+++ b/design/craft/fpga-test-socket/src/TestSocketFPGADesign.scala
@@ -15,7 +15,8 @@ class TestSocketDevKitWrapper()(implicit p: Parameters) extends DevKitWrapper()(
       mbus = topMod.mbus,
       pbus = topMod.pbus,
       ibus = topMod.ibus.fromSync,
-      testHarness = harness)
+      testHarness = harness,
+      parentNode = topMod.logicalTreeNode)
 
     p(BlockDescriptorKey).foreach { block => block.place(attachParams) }
   })

--- a/src/skeleton/SimUART.scala
+++ b/src/skeleton/SimUART.scala
@@ -73,7 +73,7 @@ abstract class SimUART(busWidthBytes: Int, c: SimUARTParams)(implicit p: Paramet
         RegField.w(8, RegWriteFn((valid, data) => {
           blackbox.io.valid := valid
           blackbox.io._byte := data
-          Bool(true)}), RegFieldDesc("data","Transmit data")))))
+          true.B}), RegFieldDesc("data","Transmit data")))))
   }
 }
 

--- a/src/skeleton/TestFinisher.scala
+++ b/src/skeleton/TestFinisher.scala
@@ -85,7 +85,7 @@ abstract class TestFinisher(busWidthBytes: Int, c: TestFinisherParams)(implicit 
         RegField.w(32, RegWriteFn((valid, data) => {
           blackbox.io.valid := valid
           blackbox.io.status := data
-          Bool(true)}), RegFieldDesc("finisher","Finish with status")))))
+          true.B}), RegFieldDesc("finisher","Finish with status")))))
   }
 }
 


### PR DESCRIPTION
Forgot to update `TestSocketDevKitWrapper` when we added the `parentNode` parameter to `BlockAttachParams`