### PR TITLE
Change name of sim uart node

### DIFF
--- a/src/skeleton/SimUART.scala
+++ b/src/skeleton/SimUART.scala
@@ -49,7 +49,7 @@ case class SimUARTParams(
 abstract class SimUART(busWidthBytes: Int, c: SimUARTParams)(implicit p: Parameters)
     extends RegisterRouter(
       RegisterRouterParams(
-        name = "serial",
+        name = "simSerial",
         compat = Seq("sifive,uart0"),
         base = c.address,
         beatBytes = busWidthBytes))

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "6043751aecc84fa77d48fe1d128baf80e23cccdf",
+        "commit": "33c04005488578dcec3ef5afc0a5d2c0bb5893b7",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "33c04005488578dcec3ef5afc0a5d2c0bb5893b7",
+        "commit": "3bff7583090a92c729150aa4efe17668383466ae",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
change the DTS name of `SimUART` from `serial` to `simSerial` because `serial` conflicts with the name of the `UART` in sifive-blocks

also depends on https://github.com/sifive/api-generator-sifive/pull/22 for the change in the stdout-path node