### PR TITLE
Add rocket-chip dependency and bump to latest rocket-chip

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,7 +5,7 @@
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },
     {
-        "commit": "4374e58fc282f9670605ce5a741436d18242e520",
+        "commit": "fcff9cc0ac5dbd92eb5da5d4b855de22c402c302",
         "name": "sifive-blocks",
         "source": "git@github.com:sifive/sifive-blocks.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -23,5 +23,10 @@
         "commit": "4656fa1de13b218826ae6ec16d5843bbf21c33da",
         "name": "soc-freedom-sifive",
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
+    },
+    {
+        "commit": "a11ee2bac9f6ff6151a63694c8983e4fc8ba1fb2",
+        "name": "rocket-chip",
+        "source": "git@github.com:chipsalliance/rocket-chip.git"
     }
 ]


### PR DESCRIPTION
This is related to but not explicitly dependent on my attempt to bump to Chisel 3.2.1+ in https://github.com/sifive/api-chisel3-sifive/pull/5.

It's kind of tricky to bump all the way to that, since rocket-chip is dependent on some experimental, unstable interfaces in Chisel3, so this takes the first step of just getting to the latest rocket-chip. I'm also planning to bump block-pio-sifive to this TestSocket, which I'll do in a parallel PR.

Note that soc-testsocket-sifive's wit-manifest.json didn't previously include rocket-chip. However, the Scala code within soc-testsocket-sifive.git does directly import from rocket-chip, so I think it is more correct to directly depend on rocket-chip here.

I also had to bump to the latest sifive-blocks in order to pull in commits that make it compatible with the latest rocket-chip.