### PR TITLE
Fix software boot method.

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -75,7 +75,7 @@ global def makeOMBlockTest name deviceType program plusargs =
 global def testfilePlusargBootloader =
   def programLoader =
     def plusarg = "testfile"
-    def memoryRegion = "testsocket-main-memory"
+    def memoryRegion = "mem"
     def score = (\_ \_ 1.0)
     def compiler = freedomMetalDUTProgramCompiler
     makePlusargProgramLoader plusarg memoryRegion score compiler

--- a/build.wake
+++ b/build.wake
@@ -75,7 +75,7 @@ global def makeOMBlockTest name deviceType program plusargs =
 global def testfilePlusargBootloader =
   def programLoader =
     def plusarg = "testfile"
-    def memoryRegion = "sram"
+    def memoryRegion = "testsocket-main-memory"
     def score = (\_ \_ 1.0)
     def compiler = freedomMetalDUTProgramCompiler
     makePlusargProgramLoader plusarg memoryRegion score compiler

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -37,7 +37,11 @@ class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubs
     beatBytes = mbus.beatBytes,
     ecc = ECCParams(bytes = mbus.beatBytes),
     parentLogicalTreeNode = Some(logicalTreeNode),
-    devName = Some("testsocket-main-memory")
+    // Warning: This devName has to match the instance name of the SRAM in the
+    // hierarchical path in
+    // https://github.com/sifive/api-generator-sifive/blob/2746926805ee00f91aacf883a8bb830c27f69ed2/vsrc/TestDriver.sv#L189
+    // so don't change it until that hardcoded path is paremeterized
+    devName = Some("mem")
   ))
 
   main_mem_sram.node := TLFragmenter(mbus) := mbus.toDRAMController(Some("main_mem_sram"))()

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -32,8 +32,13 @@ class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubs
   def resetVector: BigInt = 0x80000000L
 
   // set eccBytes equal to beatBytes so we only generate a single memory
-  val main_mem_sram = LazyModule(new TLRAM(AddressSet(resetVector, 0x10000000-1), beatBytes = mbus.beatBytes,
-    ecc = ECCParams(bytes = mbus.beatBytes)))
+  val main_mem_sram = LazyModule(new TLRAM(
+    address = AddressSet(resetVector, 0x10000000-1),
+    beatBytes = mbus.beatBytes,
+    ecc = ECCParams(bytes = mbus.beatBytes),
+    parentLogicalTreeNode = Some(logicalTreeNode),
+    devName = Some("testsocket-main-memory")
+  ))
 
   main_mem_sram.node := TLFragmenter(mbus) := mbus.toDRAMController(Some("main_mem_sram"))()
 


### PR DESCRIPTION
This makes a change to the SkeletonDUT to add the Object Model instance for the memory attached to the mbus.

This also explicitly assigns a name/description to that Object Model instance and updates the Wake function describing the boot method to target that memory name.

I've locally tested that this fixes the last remaining issue with https://github.com/sifive/block-pio-sifive/pull/48, since this makes it so that the width of the memory is properly set for the `$readmemh()` to work properly.