### PR TITLE
SkeletonDUT: set TLRAM dts compat string to 'memory'

### DIFF
--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -41,7 +41,8 @@ class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubs
     // hierarchical path in
     // https://github.com/sifive/api-generator-sifive/blob/2746926805ee00f91aacf883a8bb830c27f69ed2/vsrc/TestDriver.sv#L189
     // so don't change it until that hardcoded path is paremeterized
-    devName = Some("mem")
+    devName = Some("mem"),
+    dtsCompat = Some(Seq("memory"))
   ))
 
   main_mem_sram.node := TLFragmenter(mbus) := mbus.toDRAMController(Some("main_mem_sram"))()


### PR DESCRIPTION
new versions of freedom-devicetree-tools use a different linker script strategy that looks for `memory` in the compatible string instead of `sifive,sram0`. setting the TLRAM compatible string to `memroy` allows it to work with both old and new freedom-devicetree-tools