### PR TITLE
change wit-manifest back to older version

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "056feb97299585a944e4cb45a22b14bdec45a231",
+        "commit": "6043751aecc84fa77d48fe1d128baf80e23cccdf",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
Changing api-generator back, to keep wit-manifest pointing at older version