### PR TITLE
Use customOverlay to configure Freedom Metal

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -31,7 +31,15 @@ global def testFinisherBlock =
 global def makeSkeletonDUTPlan name blocks =
   def testharness = "sifive.skeleton.SkeletonTestHarness"
   def config = "sifive.skeleton.DefaultConfig"
+  def customOverlay =
+    def chosenNode =
+      def ram = makeDevicetreeChosenMemoryRam "/soc/mem@80000000" 0 0
+      def entry = makeDevicetreeChosenMemoryEntry "/soc/mem@80000000" 0 0
+      def itim = None
+      makeDevicetreeChosenNode entry ram itim
+    makeDevicetreeCustomOverlay Nil chosenNode
   makeRocketChipDUTPlan name sifiveSkeletonScalaModule testharness config
+  | setRocketChipDUTPlanCustomOverlay (Some customOverlay)
 
 global def makeTestSocketDUT name blocks =
   def baseDUT =

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "6043751aecc84fa77d48fe1d128baf80e23cccdf",
+        "commit": "69c73cfe30525093b4d6d7acec9d5fb854209d13",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
These are the changes to drive api-generator-sifive using the new API created in [api-generator-sifive#41](https://github.com/sifive/api-generator-sifive/pull/41).

Adds a custom Devicetree overlay to the SkeletonDUTPlan to configure Freedom metal to use the sram at 0x8000_0000 for code and data.