### PR TITLE
Move duh block instantiation loop into HasAttachedBlocks trait

### DIFF
--- a/src/skeleton/Blocks.scala
+++ b/src/skeleton/Blocks.scala
@@ -19,6 +19,6 @@ case class BlockAttachParams(
 
 case class BlockDescriptor(
   name:  String,
-  place: BlockAttachParams => Unit)
+  place: BlockAttachParams => Any)
 
 case object BlockDescriptorKey extends Field[Seq[BlockDescriptor]](Nil)


### PR DESCRIPTION
This will make it easier for other SoCs that want to instantiate duh onboarded blocks to do so by mixing in `HasAttachedBlocks`