### PR TITLE
Bump rocket-chip and matching dependencies

### DIFF
--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -24,19 +24,6 @@ trait HasAttachedBlocks { this: LazyModule =>
 
 class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubsystem with HasAttachedBlocks
 {
-  sbus.clockGroupNode := asyncClockGroupsNode
-  sbus.crossToBus(cbus, NoCrossing)
-  cbus.crossToBus(pbus, SynchronousCrossing())
-  FlipRendering { implicit p => sbus.crossFromBus(fbus, SynchronousCrossing()) }
-
-  private val BankedL2Params(nBanks, coherenceManager) = p(BankedL2Key)
-  private val (in, out, halt) = coherenceManager(this)
-  if (nBanks != 0) {
-    sbus.coupleTo("coherence_manager") { in :*= _ }
-    mbus.coupleFrom("coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
-  }
-  mbus.clockGroupNode := sbus.clockGroupNode
-
   def resetVector: BigInt = 0x80000000L
 
   // set eccBytes equal to beatBytes so we only generate a single memory

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -8,11 +8,12 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.system._
 import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.util.ECCParams
+import freechips.rocketchip.util.{DontTouch, ECCParams}
 
 class SkeletonDUTModuleImp[+L <: SkeletonDUT](_outer: L) extends RocketSubsystemModuleImp(_outer)
     with HasRTCModuleImp
-    with HasResetVectorWire {
+    with HasResetVectorWire
+    with DontTouch {
   global_reset_vector := outer.resetVector.U
 }
 

--- a/src/skeleton/SkeletonTestHarness.scala
+++ b/src/skeleton/SkeletonTestHarness.scala
@@ -10,6 +10,7 @@ class SkeletonTestHarness()(implicit p: Parameters) extends LazyModule with Lazy
 {
   val dut = LazyModule(new SkeletonDUT(this))
   lazy val module = new LazyModuleImp(this) {
+    dut.module.dontTouchPorts()
     ConstructOM.constructOM()
     Debug.tieoffDebug(dut.module.debug)
   }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "7bcafebc0ea9c975cbcd057ec97c78bac82249ef",
+        "commit": "b8ab69142b8e3d63a11ab846f5463bbccbd0a22d",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,6 +10,11 @@
         "source": "git@github.com:sifive/sifive-blocks.git"
     },
     {
+        "commit": "21ea734d809395962a8d3195a76377f6e44308f3",
+        "name": "chisel3",
+        "source": "git@github.com:freechipsproject/chisel3.git"
+    },
+    {
         "commit": "4656fa1de13b218826ae6ec16d5843bbf21c33da",
         "name": "soc-freedom-sifive",
         "source": "git@github.com:sifive/soc-freedom-sifive.git"

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,23 +1,13 @@
 [
     {
-        "commit": "69c73cfe30525093b4d6d7acec9d5fb854209d13",
+        "commit": "7bcafebc0ea9c975cbcd057ec97c78bac82249ef",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },
     {
-        "commit": "fcff9cc0ac5dbd92eb5da5d4b855de22c402c302",
+        "commit": "c1dee8234c23c8fc454108e59ecba20987f95cde",
         "name": "sifive-blocks",
         "source": "git@github.com:sifive/sifive-blocks.git"
-    },
-    {
-        "commit": "e1aa5f3f5c0cdeb204047c3ca50801d9f7ea25f1",
-        "name": "chisel3",
-        "source": "git@github.com:freechipsproject/chisel3.git"
-    },
-    {
-        "commit": "228c9a4b7432ac52178d63b8f27fe064aec71e9c",
-        "name": "firrtl",
-        "source": "git@github.com:freechipsproject/firrtl.git"
     },
     {
         "commit": "4656fa1de13b218826ae6ec16d5843bbf21c33da",
@@ -25,7 +15,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "a11ee2bac9f6ff6151a63694c8983e4fc8ba1fb2",
+        "commit": "1872f5d501221f13950aa2293939634a1e0d1735",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }


### PR DESCRIPTION
This bumps  the rocket-chip dependency to [today's (5/5/2020) master](https://github.com/chipsalliance/rocket-chip/commit/1872f5d501221f13950aa2293939634a1e0d1735) which contains the following significant feature upgrades:
- Configurable bus topologies (supplied in `rocketchip.subsystem` package)
- New `Attachable` API (required upgrade of `sifive-blocks`)
- Stage/Phase execution management and generator CLI (required upgrade of `api-generator-sifive`)
- Chisel v3.3.0 (updated dependency despite not explicitly using new features in this repo's Chisel code)
- FIRRTL v1.3.0 (uses rocket-chip's dependency)

I unpinned the (very old) chisel and firrtl dependencies, instead choosing to rely on the ones in rocket-chip's wit-manifest.

I plan to perform another (hopefully trivial) bump to the forthcoming stable release of rocket-chip in coming weeks.

So far I have only tested this against `block-pio-sifive`.