### PR TITLE
Allow for additional SkeletonDUT SRAMs

### DIFF
--- a/src/skeleton/Configs.scala
+++ b/src/skeleton/Configs.scala
@@ -47,3 +47,17 @@ class WithTestFinisher extends Config((site, here, up) => {
       name = "simTestFinisher",
       place=TestFinisherAttach.attach(TestFinisherParams(0x05000000L, "status.log"))) +: up(BlockDescriptorKey, site)
 })
+
+class WithAdditionalDUTSRAMs(addrs: Seq[AddressSet]) extends Config((site, here, up) => {
+  case BlockDescriptorKey => addrs.zipWithIndex.map { case (addr, idx) =>
+    BlockDescriptor(
+      name = s"benchmarkingSRAM$idx",
+      place = TLRAMAttach.attach(
+        TLRAMParams(
+          name = s"main_mem_sram_$idx",
+          address = addr,
+          devName = Some(s"mem-$idx"),
+          dtsCompat = Some(Seq("memory"))))
+    )
+  } ++ up(BlockDescriptorKey, site)
+})

--- a/src/skeleton/Configs.scala
+++ b/src/skeleton/Configs.scala
@@ -2,6 +2,7 @@ package sifive.skeleton
 
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.devices.tilelink.BootROMParams
+import freechips.rocketchip.diplomacy.{AddressSet}
 import freechips.rocketchip.system.{DefaultConfig => RCDefaultConfig}
 import freechips.rocketchip.subsystem.RocketTilesKey
 
@@ -14,6 +15,19 @@ class BaseSkeletonConfig extends Config((site, here, up) => {
         core = x.core.copy(useVM = false)
       )
     }
+  case BlockDescriptorKey =>
+    BlockDescriptor(
+      name = "testProgramSRAM",
+      place = TLRAMAttach.attach(
+        // Warning: Both arguments name devName has to match the instance path to the SRAM in the DUT
+        // https://github.com/sifive/api-generator-sifive/blob/2746926805ee00f91aacf883a8bb830c27f69ed2/vsrc/TestDriver.sv#L189
+        // so don't change it until that hardcoded path is paremeterized
+        TLRAMParams(
+          name = "main_mem_sram",
+          address = AddressSet(site(SkeletonResetVector), 0x10000000-1),
+          devName = Some("mem"),
+          dtsCompat = Some(Seq("memory"))))
+    ) +: up(BlockDescriptorKey, site)
 })
 
 class DefaultConfig extends Config(new BaseSkeletonConfig ++ new RCDefaultConfig)

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -8,7 +8,9 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.system._
 import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.util.{DontTouch, ECCParams}
+import freechips.rocketchip.util.{DontTouch}
+
+case object SkeletonResetVector extends Field[BigInt](0x80000000L)
 
 class SkeletonDUTModuleImp[+L <: SkeletonDUT](_outer: L) extends RocketSubsystemModuleImp(_outer)
     with HasRTCModuleImp
@@ -24,23 +26,7 @@ trait HasAttachedBlocks { this: LazyModule =>
 
 class SkeletonDUT(harness: LazyScope)(implicit p: Parameters) extends RocketSubsystem with HasAttachedBlocks
 {
-  def resetVector: BigInt = 0x80000000L
-
-  // set eccBytes equal to beatBytes so we only generate a single memory
-  val main_mem_sram = LazyModule(new TLRAM(
-    address = AddressSet(resetVector, 0x10000000-1),
-    beatBytes = mbus.beatBytes,
-    ecc = ECCParams(bytes = mbus.beatBytes),
-    parentLogicalTreeNode = Some(logicalTreeNode),
-    // Warning: This devName has to match the instance name of the SRAM in the
-    // hierarchical path in
-    // https://github.com/sifive/api-generator-sifive/blob/2746926805ee00f91aacf883a8bb830c27f69ed2/vsrc/TestDriver.sv#L189
-    // so don't change it until that hardcoded path is paremeterized
-    devName = Some("mem"),
-    dtsCompat = Some(Seq("memory"))
-  ))
-
-  main_mem_sram.node := TLFragmenter(mbus) := mbus.toDRAMController(Some("main_mem_sram"))()
+  def resetVector: BigInt = p(SkeletonResetVector)
 
   def attachParams = BlockAttachParams(
     sbus = Some(sbus),

--- a/src/skeleton/TLRAM.scala
+++ b/src/skeleton/TLRAM.scala
@@ -1,0 +1,36 @@
+package sifive.skeleton
+
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
+import freechips.rocketchip.tilelink.{TLRAM, TLFragmenter}
+import freechips.rocketchip.util.{ECCParams}
+
+case class TLRAMParams(
+  name: String,
+  address: AddressSet,
+  cacheable: Boolean = true,
+  executable: Boolean = true,
+  atomics: Boolean = false,
+  devName: Option[String] = None,
+  dtsCompat: Option[Seq[String]] = None
+)
+
+object TLRAMAttach {
+  def attach(params: TLRAMParams)(bap: BlockAttachParams): TLRAM = {
+    implicit val p: Parameters = bap.p
+    val sram = LazyModule(new TLRAM(
+      address = params.address,
+      cacheable = params.cacheable,
+      executable = params.executable,
+      atomics = params.atomics,
+      beatBytes = bap.mbus.beatBytes,
+      ecc = ECCParams(bytes = bap.mbus.beatBytes), // set eccBytes equal to beatBytes so we only generate a single memory
+      parentLogicalTreeNode = Some(bap.parentNode),
+      devName = params.devName,
+      dtsCompat = params.dtsCompat
+    ))
+    sram.suggestName(params.name)
+    sram.node := bap.mbus.coupleTo(params.name) { TLFragmenter(bap.mbus) := _ }
+    sram
+  }
+}


### PR DESCRIPTION
- Added an `attach` helper method for `TLRAM` in the `BlockAttachParams` style
- Route instantiation of SRAM(s) through `BlockDescriptorKey`
- Added `SkeletonResetVectorKey`
- Delicately ensure that the special SRAM into which the test program is loaded has its hardcoded instance path preserved
- Create a Config alteration allowing additional SRAMs to be added in the same spot (on `MBUS`)

Technical debt shuffling:
- I'm not cleaning up the brittle instance path requirement
- It would be better to handle this kind of SRAM attachment through the `Attachable`/`HasDeviceParams` pattern from `sifive-blocks` (because then the SRAMs could be added to any bus), but I'd at the moment I'd rather do that as a separate refactoring of BAP after @rmac-sifive's next round of changes.
- `SkeletonResetVectorKey` should be unified with some rocket-chip layer notion of picking a reset vector.