### PR TITLE
build.wake: reverse order in which block config alterations are applied

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -47,6 +47,7 @@ global def makeTestSocketDUT name blocks =
     | addRocketChipDUTPlanScalaBlock simUARTBlock
     | addRocketChipDUTPlanScalaBlock testFinisherBlock
   foldl addRocketChipDUTPlanScalaBlock.flip baseDUT blocks
+  | editRocketChipDUTPlanConfigs reverse
 
 global def makeBlockTest name block program plusargs =
   def bootloader = testfilePlusargBootloader
@@ -120,6 +121,7 @@ global def makeVC707TestSocketDUT name frequency blocks =
     makeRocketChipDUTPlan name scalaModule testharness ""
     | setRocketChipDUTPlanConfigs configs
   foldl addRocketChipDUTPlanScalaBlock.flip baseDUT blocks
+  | editRocketChipDUTPlanConfigs reverse
   | setRocketChipDUTPlanTestharness testharness
   | addFPGADevKitFrequencyConfig frequency
 


### PR DESCRIPTION
The order in which `Config` alterations are applied is not commutative. In terms of the order they are passed to the RTL generator command line, the left-most alteration will win over rightward alterations that affect the same `Field`. In the context of users of `soc-testsocket-sifive`, it is desirable to have the user-specified "block" `Config` alterations override any settings in the `DefaultConfig` provided by this repository. Thus, the order in which they are passed to the RTL generation step should be reversed.

@kieran-kim You should be able to cherry-pick this commit to whatever version you are using. I checked it results in a 32B memory bus for your example.