### PR TITLE
Bump api-generator-sifive and rocket-chip to master

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "6660cd8c591f2dad8f41cae49c387be9e60b60b6",
+        "commit": "0d49ba6c0dcce783eb24cc99639da028ea63b1b3",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "6fe38c3e523a2e3f91388316ca3d2d6a98e71a07",
+        "commit": "260dcfefcbe25edd590f98d337e30a0e9ae16ebe",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "466a1cb04e2f92e3a2ae62a4322bc7a6c783d7a9",
+        "commit": "4a6c9c2ecc10cfd6a3b476ba7846fb34a8d759ca",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "0d49ba6c0dcce783eb24cc99639da028ea63b1b3",
+        "commit": "45f3c98e392f8224bd40e189f837f92e6d745b6e",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "260dcfefcbe25edd590f98d337e30a0e9ae16ebe",
+        "commit": "466a1cb04e2f92e3a2ae62a4322bc7a6c783d7a9",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "1872f5d501221f13950aa2293939634a1e0d1735",
+        "commit": "6660cd8c591f2dad8f41cae49c387be9e60b60b6",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "b8ab69142b8e3d63a11ab846f5463bbccbd0a22d",
+        "commit": "6fe38c3e523a2e3f91388316ca3d2d6a98e71a07",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },


### PR DESCRIPTION
This pulls in header generation fixes for multiple memory regions and memory regions with no registers (https://github.com/sifive/api-generator-sifive/pull/66) and https://github.com/sifive/api-generator-sifive/pull/62

It also updates rocket-chip to a version which allows specification of AddressBlocks in the Object Model (https://github.com/chipsalliance/rocket-chip/pull/2437)