### PR TITLE
Add TestHarnessScope

### DIFF
--- a/src/skeleton/Configs.scala
+++ b/src/skeleton/Configs.scala
@@ -1,10 +1,13 @@
 package sifive.skeleton
 
-import freechips.rocketchip.config.Config
+import freechips.rocketchip.config.{Config, Field}
 import freechips.rocketchip.devices.tilelink.BootROMParams
 import freechips.rocketchip.diplomacy.{AddressSet}
 import freechips.rocketchip.system.{DefaultConfig => RCDefaultConfig}
 import freechips.rocketchip.subsystem.RocketTilesKey
+import freechips.rocketchip.diplomacy.LazyScope
+
+case object TestHarnessScope extends Field[Option[LazyScope]](None)
 
 class BaseSkeletonConfig extends Config((site, here, up) => {
   case BootROMParams => up(BootROMParams, site).copy(hang = 0x10000)


### PR DESCRIPTION
Adding `TestHarnessScope`, which can be used to access the testharness' `LazyScope` by querying `p: Parameters`

This PR does not update `SkeletonDUT`'s `blockAttachParams` to be populated by this key, nor am I sure this is what we'll want in the long term. This key is added to build a compatibility layer between the duh attachment API and the devices attachment API because the duh attachment API requires a reference to the testharness' `LazyScope`