### PR TITLE
Use variable for rocket-chip location

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -128,7 +128,7 @@ global def makeVC707TestSocketDUT name frequency blocks =
 publish vivadoVsrcHooks =
   def makeSource file _ = source file, Nil
   makeBlackBoxHook "PowerOnResetFPGAOnly" "fpga-shells/xilinx/common/vsrc/PowerOnResetFPGAOnly.v".makeSource,
-  makeBlackBoxHook "EICG_wrapper" "rocket-chip/src/main/resources/vsrc/EICG_wrapper.v".makeSource,
+  makeBlackBoxHook "EICG_wrapper" "{rocketChipRoot}/src/main/resources/vsrc/EICG_wrapper.v".makeSource,
   makeBlackBoxHook "AnalogToUInt" "fpga-shells/xilinx/common/vsrc/AnalogToUInt.v".makeSource,
   makeBlackBoxHook "UIntToAnalog" "fpga-shells/xilinx/common/vsrc/UIntToAnalog.v".makeSource,
   Nil

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "45f3c98e392f8224bd40e189f837f92e6d745b6e",
+        "commit": "5ede0829b7a926ffa29d2df8238dbfe44065128c",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }


### PR DESCRIPTION
Replaces a hard-coded location with a variable that rocket-chip itself provides to determine its location.

If rocket-chip were to change depth within the wit checkout layout, the consumers of rocket-chip would need to use this variable to find it.

(and bumps wit-manifest so that the variable exists)