### PR TITLE
Bump rocket-chip to latest master

### DIFF
--- a/src/skeleton/Configs.scala
+++ b/src/skeleton/Configs.scala
@@ -1,16 +1,18 @@
 package sifive.skeleton
 
 import freechips.rocketchip.config.{Config, Field}
-import freechips.rocketchip.devices.tilelink.BootROMParams
+import freechips.rocketchip.devices.tilelink.BootROMLocated
+import freechips.rocketchip.subsystem.InSubsystem
 import freechips.rocketchip.diplomacy.{AddressSet}
 import freechips.rocketchip.system.{DefaultConfig => RCDefaultConfig}
-import freechips.rocketchip.subsystem.RocketTilesKey
+import freechips.rocketchip.subsystem.{RocketTilesKey, InSubsystem, SubsystemExternalResetVectorKey}
 import freechips.rocketchip.diplomacy.LazyScope
 
 case object TestHarnessScope extends Field[Option[LazyScope]](None)
 
 class BaseSkeletonConfig extends Config((site, here, up) => {
-  case BootROMParams => up(BootROMParams, site).copy(hang = 0x10000)
+  case BootROMLocated(InSubsystem) => up(BootROMLocated(InSubsystem), site).map(_.copy(hang = 0x10000))
+  case SubsystemExternalResetVectorKey => true
   case RocketTilesKey =>
     up(RocketTilesKey, site).map { x =>
       x.copy(

--- a/src/skeleton/SkeletonDUT.scala
+++ b/src/skeleton/SkeletonDUT.scala
@@ -14,10 +14,7 @@ case object SkeletonResetVector extends Field[BigInt](0x80000000L)
 
 class SkeletonDUTModuleImp[+L <: SkeletonDUT](_outer: L) extends RocketSubsystemModuleImp(_outer)
     with HasRTCModuleImp
-    with HasResetVectorWire
-    with DontTouch {
-  global_reset_vector := outer.resetVector.U
-}
+    with DontTouch
 
 trait HasAttachedBlocks { this: LazyModule =>
   def attachParams: BlockAttachParams

--- a/src/skeleton/SkeletonTestHarness.scala
+++ b/src/skeleton/SkeletonTestHarness.scala
@@ -13,5 +13,8 @@ class SkeletonTestHarness()(implicit p: Parameters) extends LazyModule with Lazy
     dut.module.dontTouchPorts()
     ConstructOM.constructOM()
     Debug.tieoffDebug(dut.module.debug)
+
+    dut.module.reset_vector.foreach { _ := p(SkeletonResetVector).U }
+
   }
 }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "5ede0829b7a926ffa29d2df8238dbfe44065128c",
+        "commit": "674f8caaf07f7390925ce08004c5cc42c479e942",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }


### PR DESCRIPTION
This is needed to pick up a fix for the bootrom path by @richardxia. There are some backwards incompatible changes that were addressed in this PR as well as relates to BootROM and ResetVector parameterization. 