### PR TITLE
Bump rocket-chip to pick up fix for bundlebridge parenthesis

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
     },
     {
-        "commit": "674f8caaf07f7390925ce08004c5cc42c479e942",
+        "commit": "52843da3d8daaba5c32c488ee21d20aa2f640772",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     }


### PR DESCRIPTION
Rather than requiring a fix in https://github.com/sifive/duh-scala/issues/83 this has been fixed in https://github.com/chipsalliance/rocket-chip/pull/2533, so bumping rocket-chip past that fix to pick it up