### PR TITLE
Add Wake 0.19 CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,58 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test-rtl-test-socket:
+    name: Compile TestSocketDUT
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Wit Init
+      uses: sifive/wit/actions/init@v0.13.2
+      with:
+        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+
+    - name: Compile
+      uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
+      with:
+        command: -x 'makeRTL (makeTestSocketDUT "noop" Nil)'
+
+  test-vc707-test-socket:
+    name: Compile VC707TestSocketDUT
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Wit Init
+      uses: sifive/wit/actions/init@v0.13.2
+      with:
+        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+
+    - name: Compile
+      uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
+      with:
+        command: -x 'makeRTL (makeVC707TestSocketDUT "noop" 50 Nil)'
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run lint check
+      run: |
+        set +e  # GitHub defaults to -e, but we want to do our own error handling
+
+        if matching_files=$(grep --files-with-matches '\s\+$' *); then
+          echo "Trailing whitespace detected. Please remove trailing whitespace in the following files:"
+          echo
+          echo "$matching_files"
+          exit 1
+        fi

--- a/build.wake
+++ b/build.wake
@@ -28,7 +28,7 @@ global def testFinisherBlock =
   def config = "sifive.skeleton.WithTestFinisher"
   makeScalaBlock module config
 
-global def makeSkeletonDUTPlan name blocks =
+global def makeSkeletonDUTPlan name _blocks =
   def testharness = "sifive.skeleton.SkeletonTestHarness"
   def config = "sifive.skeleton.DefaultConfig"
   def customOverlay =

--- a/build.wake
+++ b/build.wake
@@ -1,17 +1,3 @@
-# Borrowed from future wake; can be removed once we've migrated to wake 0.16
-def root /../ filterFn = jfind filterFn root
-def jfind filterFn root =
-  def helper node acc = match node
-    JArray l =
-      def tail = foldr helper acc l
-      if filterFn node then node, tail else tail
-    JObject l =
-      def tail = foldr (helper _.getPairSecond _) acc l
-      if filterFn node then node, tail else tail
-    _ =
-      if filterFn node then node, acc else acc
-  helper root Nil | JArray
-
 global def sifiveSkeletonScalaModule =
   makeScalaModuleFromJSON here "sifiveSkeleton"
   | setScalaModuleSourceDirs ("src", Nil)

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "4a6c9c2ecc10cfd6a3b476ba7846fb34a8d759ca",
+        "commit": "345deea1bc819255e9e29a2b1c1d6e0a5c0a362d",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,23 +5,8 @@
         "source": "git@github.com:sifive/api-generator-sifive.git"
     },
     {
-        "commit": "c1dee8234c23c8fc454108e59ecba20987f95cde",
-        "name": "sifive-blocks",
-        "source": "git@github.com:sifive/sifive-blocks.git"
-    },
-    {
-        "commit": "21ea734d809395962a8d3195a76377f6e44308f3",
-        "name": "chisel3",
-        "source": "git@github.com:freechipsproject/chisel3.git"
-    },
-    {
-        "commit": "4656fa1de13b218826ae6ec16d5843bbf21c33da",
+        "commit": "4c50f5e1bafc366d9c9f32a55a1ddcf26e57c9db",
         "name": "soc-freedom-sifive",
         "source": "git@github.com:sifive/soc-freedom-sifive.git"
-    },
-    {
-        "commit": "52843da3d8daaba5c32c488ee21d20aa2f640772",
-        "name": "rocket-chip",
-        "source": "git@github.com:chipsalliance/rocket-chip.git"
     }
 ]


### PR DESCRIPTION
In addition to adding a couple of CI tests to actually attempt compiling and generating RTL for the TestSocketDUT, this makes a few other minor changes for Wake 0.19 compatibility:

- https://github.com/sifive/soc-testsocket-sifive/commit/133f26d2507493e51bb4ddd4ed5c21c2619482a3 Bumping api-generator-sifive to pull in all the other Wake 0.19 fixes (these should all still be compatible with Wake 0.17.2)
- https://github.com/sifive/soc-testsocket-sifive/commit/5a03f284cbc0b5b233ec90b3e533ad6f71fdea50 Renaming an unused argument
- https://github.com/sifive/soc-testsocket-sifive/commit/bc440f740013673cd2dff998b273df1808473836 Removing an old shim from when we were trying to straddle Wake 0.15 and Wake 0.17.